### PR TITLE
feat: adjust Multiprocessing to default parameters

### DIFF
--- a/src/cbdgen-framework.py
+++ b/src/cbdgen-framework.py
@@ -172,7 +172,7 @@ def results(options: dict, toolbox: base.Toolbox):
     mutpb = options['MUTPB']
     ngen = options['NGEN']
     random.seed(64)
-    pool = multiprocessing.Pool(processes=12)
+    pool = multiprocessing.Pool()
     toolbox.register("map", pool.map)
     # Initialize statistics object
     stats = tools.Statistics(lambda ind: ind.fitness.values)


### PR DESCRIPTION
This PR implements an adjustment to a parameter of Multiprocessing, before we were creating 12 processes, but this is an optional parameter, since there are multiple processors with multiple cores, by enabling the default value, `multiprocessing` package will ask the os How much cores does the CPU have, enabling a performance improvement based on the setup.

Take my setup for example, since the default values has been used, there was an improvement of over a **0.1 seconds** on the evaluation time.